### PR TITLE
fixing hybrid version numbers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "iron-selector": "PolymerElements/iron-selector#1 - 2",
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#1 - 2",
     "d2l-colors": "^2.4.0 || ^3.1.0",
-    "d2l-dropdown": "^5.1.1",
+    "d2l-dropdown": "^5.1.1 || ^6.0.0",
     "d2l-typography": "^5.4.0 || ^6.0.0",
     "d2l-intl": "^0.4.1"
   },
@@ -23,6 +23,7 @@
     "1.x": {
       "dependencies": {
         "d2l-colors": "^2.4.0",
+        "d2l-dropdown": "^5.1.1",
         "polymer": "Polymer/polymer#^1.9.1",
         "iron-selector": "PolymerElements/iron-selector#^1.0.0",
         "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
@@ -40,8 +41,5 @@
         "webcomponentsjs": "^0.7"
       }
     }
-  },
-  "resolutions": {
-    "webcomponentsjs": "^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#1 - 2",
     "d2l-colors": "^2.4.0 || ^3.1.0",
     "d2l-dropdown": "^5.1.1",
-    "d2l-typography": "^5.4.0",
+    "d2l-typography": "^5.4.0 || ^6.0.0",
     "d2l-intl": "^0.4.1"
   },
   "devDependencies": {
@@ -17,7 +17,7 @@
     "iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#0.7 - 1",
-    "d2l-demo-template": "^0.0.12"
+    "d2l-demo-template": "^0.0.12 || ^1.0.1"
   },
   "variants": {
     "1.x": {
@@ -25,14 +25,16 @@
         "d2l-colors": "^2.4.0",
         "polymer": "Polymer/polymer#^1.9.1",
         "iron-selector": "PolymerElements/iron-selector#^1.0.0",
-        "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
+        "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
+        "d2l-typography": "^5.4.0"
       },
       "devDependencies": {
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
         "web-component-tester": "Polymer/web-component-tester#^4.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+        "d2l-demo-template": "^0.0.12"
       },
       "resolutions": {
         "webcomponentsjs": "^0.7"
@@ -40,6 +42,6 @@
     }
   },
   "resolutions": {
-    "webcomponentsjs": "0.7 - 1"
+    "webcomponentsjs": "^1.0.0"
   }
 }

--- a/d2l-time-picker.html
+++ b/d2l-time-picker.html
@@ -178,7 +178,7 @@ Accessible, Localized Time Picker Input Element
 
 			listeners: {
 				'iron-select': '_scrollSelectedItemIntoView',
-				'dropdown.tap': '_handleTimesListClick'
+				'tap': '_handleTimesListClick'
 			},
 
 			keyBindings: {
@@ -337,9 +337,11 @@ Accessible, Localized Time Picker Input Element
 			},
 
 			_handleTimesListClick: function(e) {
-				this.$$('input').focus();
-				this._closeTimesList(true);
-				e.preventDefault();
+				if (Polymer.dom(e).rootTarget !== this.$$('input')) {
+					this.$$('input').focus();
+					this._closeTimesList(true);
+					e.preventDefault();
+				}
 			},
 
 			_onTimeInputKeyPressed: function(e) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-template title="d2l-time-picker">
-			<div class="d2l-demo-fixture">
+			<div slot="d2l-demo-fixture" class="d2l-demo-fixture">
 				<dom-bind>
 					<template is="dom-bind">
 						<label>Locale: <input value="{{locale::input}}"/></label>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "d2l-time-picker",
   "description": "Accessible, Localized Time Picker Input Element",
   "scripts": {
-    "postinstall": "polymer install",
+    "postinstall": "polymer install --variants",
     "test": "npm run test:lint && polymer test --skip-plugin sauce",
     "test:lint": "npm run test:lint:wc && npm run test:lint:html",
     "test:lint:html": "eslint *.html",
@@ -12,9 +12,9 @@
     "dump:galen:local:run": "npm run galen -- dump test/acceptance/galen.test.js -g factory:local -d test/acceptance/dumps",
     "galen:local:run": "npm run galen -- test test/acceptance/galen.test.js -g factory:local -- -p4",
     "galen:sauce:run": "sc-run -- npm run galen -- test test/acceptance/galen.test.js -g factory:sauce -i SAUCE_USERNAME SAUCE_ACCESS_KEY TRAVIS_REPO_SLUG TRAVIS_BUILD_NUMBER -- -p4",
-    "dump:galen:local": "concurrently -p name -n serve,galen -s first -k \"polymer serve -p 8080\" \"npm run dump:galen:local:run\"",
-    "test:galen:local": "concurrently -p name -n serve,galen -s first -k \"polymer serve -p 8080\" \"npm run galen:local:run\"",
-    "test:galen:sauce": "concurrently -p name -n serve,galen -s first -k \"polymer serve -p 8080\" \"npm run galen:sauce:run\""
+    "dump:galen:local": "concurrently -p name -n serve,galen -s first -k \"polymer serve\" \"npm run dump:galen:local:run\"",
+    "test:galen:local": "concurrently -p name -n serve,galen -s first -k \"polymer serve\" \"npm run galen:local:run\"",
+    "test:galen:sauce": "concurrently -p name -n serve,galen -s first -k \"polymer serve\" \"npm run galen:sauce:run\""
   },
   "repository": {
     "type": "git",

--- a/test/acceptance/galen.test.js
+++ b/test/acceptance/galen.test.js
@@ -46,8 +46,8 @@ var browsers = {
 	})*/
 };
 
-var endpoint = 'http://localhost:8080/components/d2l-time-picker/demo/index.html';
-//var demoEndpoint = 'http://localhost:8080/components/d2l-time-picker/demo/index.html';
+var mainlineEndpoint = 'http://localhost:8081/components/d2l-time-picker/demo/';
+var xEndpoint = 'http://localhost:8000/components/d2l-time-picker/demo/';
 
 var TimePickerDemoPage = $page('Time Picker Demo Page', {
 	input: 'xpath: //d2l-time-picker//*[contains(@class,\'d2l-input\')]'
@@ -58,67 +58,74 @@ var TimePickerShadowDemoPage = $page('Time Picker Demo Page', {
 });
 
 polymerTests(browsers, function(test) {
-	test('d2l-time-picker', {
-		endpoint: endpoint + '?wc-shadydom',
-		spec: 'test/acceptance/timepicker.gspec',
-		tags: ['closed', 'ltr']
-	});
+	function runTests(endpoint, runShadow) {
+		test('d2l-time-picker', {
+			endpoint: endpoint + '?wc-shadydom',
+			spec: 'test/acceptance/timepicker.gspec',
+			tags: ['closed', 'ltr']
+		});
 
-	test('d2l-time-picker-open', {
-		endpoint: endpoint + '?wc-shadydom',
-		spec: 'test/acceptance/timepicker.gspec',
-		tags: ['open', 'ltr']
-	}, function(opts, cb) {
-		var timepickerdemopage = new TimePickerDemoPage(opts.driver);
-		timepickerdemopage.input.click();
-		cb();
-	});
+		test('d2l-time-picker-open', {
+			endpoint: endpoint + '?wc-shadydom',
+			spec: 'test/acceptance/timepicker.gspec',
+			tags: ['open', 'ltr']
+		}, function(opts, cb) {
+			var timepickerdemopage = new TimePickerDemoPage(opts.driver);
+			timepickerdemopage.input.clickAt(10, 10);
+			cb();
+		});
 
-	test('d2l-time-picker-rtl', {
-		endpoint: endpoint + '?dir=rtl&wc-shadydom',
-		spec: 'test/acceptance/timepicker.gspec',
-		tags: ['closed', 'rtl']
-	});
+		test('d2l-time-picker-rtl', {
+			endpoint: endpoint + '?dir=rtl&wc-shadydom',
+			spec: 'test/acceptance/timepicker.gspec',
+			tags: ['closed', 'rtl']
+		});
 
-	test('d2l-time-picker-open-rtl', {
-		endpoint: endpoint + '?dir=rtl&wc-shadydom',
-		spec: 'test/acceptance/timepicker.gspec',
-		tags: ['open', 'rtl']
-	}, function(opts, cb) {
-		var timepickerdemopage = new TimePickerDemoPage(opts.driver);
-		timepickerdemopage.input.click();
-		cb();
-	});
+		test('d2l-time-picker-open-rtl', {
+			endpoint: endpoint + '?dir=rtl&wc-shadydom',
+			spec: 'test/acceptance/timepicker.gspec',
+			tags: ['open', 'rtl']
+		}, function(opts, cb) {
+			var timepickerdemopage = new TimePickerDemoPage(opts.driver);
+			timepickerdemopage.input.clickAt(10, 10);
+			cb();
+		});
 
-	test.shadow('d2l-time-picker-shadow', {
-		endpoint: endpoint + '?dom=shadow',
-		spec: 'test/acceptance/timepicker.shadow.gspec',
-		tags: ['closed', 'ltr']
-	});
+		if (runShadow) {
+			test.shadow('d2l-time-picker-shadow', {
+				endpoint: endpoint + '?dom=shadow',
+				spec: 'test/acceptance/timepicker.shadow.gspec',
+				tags: ['closed', 'ltr']
+			});
 
-	test.shadow('d2l-time-picker-open-shadow', {
-		endpoint: endpoint + '?dom=shadow',
-		spec: 'test/acceptance/timepicker.shadow.gspec',
-		tags: ['open', 'ltr']
-	}, function(opts, cb) {
-		var timepickerdemopage = new TimePickerShadowDemoPage(opts.driver);
-		timepickerdemopage.input.click();
-		cb();
-	});
+			test.shadow('d2l-time-picker-open-shadow', {
+				endpoint: endpoint + '?dom=shadow',
+				spec: 'test/acceptance/timepicker.shadow.gspec',
+				tags: ['open', 'ltr']
+			}, function(opts, cb) {
+				var timepickerdemopage = new TimePickerShadowDemoPage(opts.driver);
+				timepickerdemopage.input.clickAt(10, 10);
+				cb();
+			});
 
-	test.shadow('d2l-time-picker-rtl-shadow', {
-		endpoint: endpoint + '?dir=rtl&dom=shadow',
-		spec: 'test/acceptance/timepicker.shadow.gspec',
-		tags: ['closed', 'rtl']
-	});
+			test.shadow('d2l-time-picker-rtl-shadow', {
+				endpoint: endpoint + '?dir=rtl&dom=shadow',
+				spec: 'test/acceptance/timepicker.shadow.gspec',
+				tags: ['closed', 'rtl']
+			});
 
-	test.shadow('d2l-time-picker-open-rtl-shadow', {
-		endpoint: endpoint + '?dir=rtl&dom=shadow',
-		spec: 'test/acceptance/timepicker.shadow.gspec',
-		tags: ['open', 'rtl']
-	}, function(opts, cb) {
-		var timepickerdemopage = new TimePickerShadowDemoPage(opts.driver);
-		timepickerdemopage.input.click();
-		cb();
-	});
+			test.shadow('d2l-time-picker-open-rtl-shadow', {
+				endpoint: endpoint + '?dir=rtl&dom=shadow',
+				spec: 'test/acceptance/timepicker.shadow.gspec',
+				tags: ['open', 'rtl']
+			}, function(opts, cb) {
+				var timepickerdemopage = new TimePickerShadowDemoPage(opts.driver);
+				timepickerdemopage.input.clickAt(10, 10);
+				cb();
+			});
+		}
+	}
+
+	runTests(mainlineEndpoint, false);
+	runTests(xEndpoint);
 });

--- a/test/acceptance/galen.test.js
+++ b/test/acceptance/galen.test.js
@@ -127,5 +127,5 @@ polymerTests(browsers, function(test) {
 	}
 
 	runTests(mainlineEndpoint, false);
-	runTests(xEndpoint);
+	runTests(xEndpoint, true);
 });

--- a/test/acceptance/galen.test.js
+++ b/test/acceptance/galen.test.js
@@ -50,7 +50,7 @@ var endpoint = 'http://localhost:8080/components/d2l-time-picker/demo/index.html
 //var demoEndpoint = 'http://localhost:8080/components/d2l-time-picker/demo/index.html';
 
 var TimePickerDemoPage = $page('Time Picker Demo Page', {
-	input: 'd2l-time-picker .d2l-input'
+	input: 'xpath: //d2l-time-picker//*[contains(@class,\'d2l-input\')]'
 });
 
 var TimePickerShadowDemoPage = $page('Time Picker Demo Page', {
@@ -59,13 +59,13 @@ var TimePickerShadowDemoPage = $page('Time Picker Demo Page', {
 
 polymerTests(browsers, function(test) {
 	test('d2l-time-picker', {
-		endpoint: endpoint,
+		endpoint: endpoint + '?wc-shadydom',
 		spec: 'test/acceptance/timepicker.gspec',
 		tags: ['closed', 'ltr']
 	});
 
 	test('d2l-time-picker-open', {
-		endpoint: endpoint,
+		endpoint: endpoint + '?wc-shadydom',
 		spec: 'test/acceptance/timepicker.gspec',
 		tags: ['open', 'ltr']
 	}, function(opts, cb) {
@@ -75,13 +75,13 @@ polymerTests(browsers, function(test) {
 	});
 
 	test('d2l-time-picker-rtl', {
-		endpoint: endpoint + '?dir=rtl',
+		endpoint: endpoint + '?dir=rtl&wc-shadydom',
 		spec: 'test/acceptance/timepicker.gspec',
 		tags: ['closed', 'rtl']
 	});
 
 	test('d2l-time-picker-open-rtl', {
-		endpoint: endpoint + '?dir=rtl',
+		endpoint: endpoint + '?dir=rtl&wc-shadydom',
 		spec: 'test/acceptance/timepicker.gspec',
 		tags: ['open', 'rtl']
 	}, function(opts, cb) {

--- a/test/acceptance/timepicker.gspec
+++ b/test/acceptance/timepicker.gspec
@@ -1,8 +1,8 @@
 @objects
 
 	timepicker-container        d2l-time-picker
-		input                   .d2l-input
-		dropdown                d2l-dropdown-content
+		input                   xpath //d2l-time-picker//*[contains(@class,'d2l-input')]
+		dropdown                xpath //d2l-time-picker//d2l-dropdown-content
 			content             .dropdown-content
 				listbox         iron-selector
 					time-item-* .d2l-times-item

--- a/test/d2l-time-picker_test.html
+++ b/test/d2l-time-picker_test.html
@@ -186,13 +186,9 @@
 									expect(times).to.deep.equal(expectations);
 									done();
 								}
+								selector.addEventListener('iron-items-changed', doTest);
 								this.element.timeInterval = 20;
 								this.focusElement();
-								if (selector.items.length) {
-									doTest();
-								} else {
-									selector.addEventListener('iron-items-changed', doTest);
-								}
 							});
 
 							test('shown when input is focused', function(done) {

--- a/test/d2l-time-picker_test.html
+++ b/test/d2l-time-picker_test.html
@@ -314,11 +314,18 @@
 
 							test('selects when item is tapped', function(done) {
 								var listbox = this.element.$$('iron-selector');
-								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+								function finish() {
 									listbox.selectIndex(5);
 									MockInteractions.tap(listbox.items[0]);
 									expect(listbox.selected).to.equal(0);
 									done();
+								}
+								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+									if (listbox.items.length === 0) {
+										listbox.addEventListener('iron-items-changed', finish);
+									} else {
+										finish();
+									}
 								});
 								this.focusElement();
 							});
@@ -326,11 +333,18 @@
 							test('selects next when down is pressed', function(done) {
 								var inputElement = this.inputElement;
 								var listbox = this.element.$$('iron-selector');
-								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+								function finish() {
 									expect(listbox.selected).to.equal(0);
 									MockInteractions.pressAndReleaseKeyOn(inputElement, 40);
 									expect(listbox.selected).to.equal(1);
 									done();
+								}
+								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+									if (listbox.items.length === 0) {
+										listbox.addEventListener('iron-items-changed', finish);
+									} else {
+										finish();
+									}
 								});
 								this.element.hours = 0;
 								this.element.minutes = 0;
@@ -340,11 +354,18 @@
 							test('selects previous when up is pressed', function(done) {
 								var inputElement = this.inputElement;
 								var listbox = this.element.$$('iron-selector');
-								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+								function finish() {
 									expect(listbox.selected).to.equal(2);
 									MockInteractions.pressAndReleaseKeyOn(inputElement, 38);
 									expect(listbox.selected).to.equal(1);
 									done();
+								}
+								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+									if (listbox.items.length === 0) {
+										listbox.addEventListener('iron-items-changed', finish);
+									} else {
+										finish();
+									}
 								});
 								this.element.hours = 1;
 								this.element.minutes = 0;
@@ -354,11 +375,18 @@
 							test('selects first item when home is pressed', function(done) {
 								var inputElement = this.inputElement;
 								var listbox = this.element.$$('iron-selector');
-								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+								function finish() {
 									listbox.selectIndex(5);
 									MockInteractions.pressAndReleaseKeyOn(inputElement, 36);
 									expect(listbox.selected).to.equal(0);
 									done();
+								}
+								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+									if (listbox.items.length === 0) {
+										listbox.addEventListener('iron-items-changed', finish);
+									} else {
+										finish();
+									}
 								});
 								this.focusElement();
 							});
@@ -366,28 +394,42 @@
 							test('selects last item when end is pressed', function(done) {
 								var inputElement = this.inputElement;
 								var listbox = this.element.$$('iron-selector');
-								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+								function finish() {
 									listbox.selectIndex(5);
 									MockInteractions.pressAndReleaseKeyOn(inputElement, 35);
 									expect(listbox.selected).to.equal(47);
 									done();
+								}
+								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+									if (listbox.items.length === 0) {
+										listbox.addEventListener('iron-items-changed', finish);
+									} else {
+										finish();
+									}
 								});
 								this.focusElement();
 							});
 
-							test('updates time when enter is pressed', function() {
+							test('updates time when enter is pressed', function(done) {
 								var inputElement = this.inputElement;
 								var listbox = this.element.$$('iron-selector');
 								var element = this.element;
-								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+								function finish() {
 									expect(element.value).to.not.equal(listbox.items[5].textContent.trim());
 									listbox.selectIndex(5);
 									MockInteractions.pressEnter(inputElement);
 									expect(!!element.$.dropdown.opened).to.be.false;
 									expect(element.value).to.equal(listbox.items[5].textContent.trim());
+									done();
+								}
+								this.element.$.dropdown.addEventListener('d2l-dropdown-open', function() {
+									if (listbox.items.length === 0) {
+										listbox.addEventListener('iron-items-changed', finish);
+									} else {
+										finish();
+									}
 								});
 								this.focusElement();
-								this.element.value = '';
 							});
 
 							test('resets to valid value when closed when enter is pressed', function() {


### PR DESCRIPTION
I think these changes are required to make this hybrid-compatible.

So far we've learned that for hybrid components you need a range in the 2.x (main) dependency list that covers the 1.x and 2.x versions of each dependency, ALL of which need to be hybrid. So dropdown may be an issues for you, since it's not hybrid yet.

Next, the 1.x dependency variant should list the 1.x versions of the dependencies.

You'll likely need to also install dependencies using `polymer install --variants` instead of `bower install` if you want `polymer test` and `polymer lint` to test both variations.