### PR TITLE
Add invalid attribute to toggle input error styling 

### DIFF
--- a/d2l-time-picker.js
+++ b/d2l-time-picker.js
@@ -82,6 +82,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-time-picker">
 					aria-label$="{{label}}"
 					aria-owns$="{{listboxId}}"
 					aria-activedescendant$="{{selectedListboxId}}"
+					aria-invalid$="[[_computedAriaInvalid(invalid)]]"
 					on-focus="_onTimeInputFocused"
 					value="{{value::input}}">
 			</div>
@@ -153,7 +154,12 @@ Polymer({
 		_dropdownWidth: String,
 		listboxId: String,
 		selectedListboxId: String,
-		label: String
+		label: String,
+		invalid: {
+			type: Boolean,
+			value: false,
+			reflectToAttribute: true
+		}
 	},
 
 	observers: [
@@ -365,5 +371,9 @@ Polymer({
 				return;
 		}
 		e.preventDefault();
+	},
+
+	_computedAriaInvalid: function(invalid) {
+		return invalid ? 'true' : 'false';
 	}
 });

--- a/d2l-time-picker.js
+++ b/d2l-time-picker.js
@@ -157,8 +157,7 @@ Polymer({
 		label: String,
 		invalid: {
 			type: Boolean,
-			value: false,
-			reflectToAttribute: true
+			value: false
 		}
 	},
 


### PR DESCRIPTION
Adding the `invalid` attribute the the component will set `aria-invalid` on input field, which will highlight the input in red.